### PR TITLE
⭐ Add Wally Publishing

### DIFF
--- a/.github/workflows/PublishAssets.yml
+++ b/.github/workflows/PublishAssets.yml
@@ -1,4 +1,4 @@
-name: Publish To Roblox
+name: Publish To Roblox & Wally
 
 on:
   push:
@@ -23,8 +23,18 @@ jobs:
     - name: Report tool versions
       run: rojo --version
 
-    - name: Deploy
+    - name: Deploy to Roblox
       run: |
         rojo upload --cookie "$ROBLOSECURITY" --asset_id 6245329519 src
       env:
         ROBLOSECURITY: ${{ secrets.ROBLOSECURITY }} # d
+
+    - name: Login to Wally
+      run: |
+          mkdir ~/.wally
+          printenv WALLY_AUTH > ~/.wally/auth.toml
+      env:
+        WALLY_AUTH: ${{ secrets.WALLY_AUTH }}
+
+    - name: Publish to Wally
+      run: wally publish

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,3 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "6.0.2" }
 tarmac = { source = "rojo-rbx/tarmac", version = "0.4.0" }
+wally = { source = "UpliftGames/Wally", version = "0.3.2" }

--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,14 @@
+[package]
+name = "1foreverhd/zoneplus"
+description = "Construct dynamic zones that utilise region checking, raycasting and the new BasePart.CanTouch property to effectively determine players and parts within their boundaries."
+license = "MIT"
+realm = "shared"
+registry = "https://github.com/UpliftGames/wally-index"
+version = "3.2.0"
+exclude = [
+	"docs", ".moonwave", "test",
+	"ZonePlus.rbxm", "ZonePlus.rbxmx",
+	".gitignore", "foreman.toml",
+]
+
+[dependencies]


### PR DESCRIPTION
Addresses #54 

This PR adds automated Wally publishing as an additional step to your GitHub Deployment Action.

There are a few steps you need to take to make sure this works correctly before merging this PR:

1. [Install Wally](https://wally.run/install)
2. Run `wally login`
  a. This will generate a file at `~/.wally/auth.toml` or `%userprofile%/.wally/auth.toml` on Windows
3. Copy (all of) the contents of this file and paste it into a new Repository Secret called `WALLY_AUTH` (as you have done for `ROBLOSECURITY`