### PR TITLE
Add types for Zone and Signal

### DIFF
--- a/src/Zone/Janitor.lua
+++ b/src/Zone/Janitor.lua
@@ -92,7 +92,7 @@ function Janitor.__index:Add(Object, MethodName, Index)
 
 	MethodName = MethodName or TypeDefaults[typeof(Object)] or "Destroy"
 	if type(Object) ~= "function" and not Object[MethodName] then
-		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(nil, 2)))
+		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(2)))
 	end
 
 	self[Object] = MethodName

--- a/src/Zone/Signal.lua
+++ b/src/Zone/Signal.lua
@@ -49,6 +49,21 @@ local function runEventHandlerInFreeThread(...)
 	end
 end
 
+export type _ConnectionProperties = {
+	_connected: boolean,
+	_signal: _Signal,
+	_fn: (...any) -> (),
+	_next: _Connection | false
+}
+
+export type Connection = {
+	Disconnect: (self: Connection) -> (),
+}
+
+export type _Connection = _ConnectionProperties & {
+	Disconnect: (self: _Connection) -> (),
+}
+
 -- Connection class
 local Connection = {}
 Connection.__index = Connection
@@ -99,13 +114,42 @@ setmetatable(Connection, {
 	end
 })
 
+export type SignalProperties = {
+	totalConnections: number,
+	connectionsChanged: Signal
+}
+
+export type _SignalProperties = {
+	_handlerListHead: _Connection | false,
+	totalConnections: number,
+	connectionsChanged: Signal
+}
+
+export type Signal = SignalProperties & {
+	new: (createConnectionsChangedSignal: boolean) -> Signal,
+	-- Methods
+	Fire: (self: Signal, ...any) -> (),
+	Connect: (self: Signal, callback: (...any) -> ()) -> Connection,
+	DisconnectAll: (self: Signal) -> (),
+	Wait: (self: Signal) -> ...any,
+}
+
+export type _Signal = _SignalProperties & {
+	new: (createConnectionsChangedSignal: boolean) -> _Signal,
+	-- Methods
+	Fire: (self: _Signal, ...any) -> (),
+	Connect: (self: _Signal, callback: (...any) -> (...any)) -> Connection,
+	DisconnectAll: (self: _Signal) -> (),
+	Wait: (self: _Signal) -> ...any,
+}
+
 -- Signal class
 local Signal = {}
 Signal.__index = Signal
 
 function Signal.new(createConnectionsChangedSignal)
 	local self = setmetatable({
-		_handlerListHead = false,	
+		_handlerListHead = false,
 	}, Signal)
     if createConnectionsChangedSignal then
         self.totalConnections = 0

--- a/src/Zone/ZoneController/Tracker.lua
+++ b/src/Zone/ZoneController/Tracker.lua
@@ -230,7 +230,7 @@ function Tracker:update()
 	
 	-- This creates the whitelist so that
 	self.whitelistParams = OverlapParams.new()
-	self.whitelistParams.FilterType = Enum.RaycastFilterType.Whitelist
+	self.whitelistParams.FilterType = Enum.RaycastFilterType.Include
 	self.whitelistParams.MaxParts = #self.parts
 	self.whitelistParams.FilterDescendantsInstances = self.parts
 end

--- a/src/Zone/ZoneController/init.lua
+++ b/src/Zone/ZoneController/init.lua
@@ -413,7 +413,7 @@ function ZoneController.getTouchingZones(item, onlyActiveZones, recommendedDetec
 	local partToZoneDict = (onlyActiveZones and activePartToZone) or allPartToZone
 
 	local boundParams = OverlapParams.new()
-	boundParams.FilterType = Enum.RaycastFilterType.Whitelist
+	boundParams.FilterType = Enum.RaycastFilterType.Include
 	boundParams.MaxParts = #partsTable
 	boundParams.FilterDescendantsInstances = partsTable
 
@@ -442,7 +442,7 @@ function ZoneController.getTouchingZones(item, onlyActiveZones, recommendedDetec
 	if totalRemainingBoundParts > 0 then
 		
 		local preciseParams = OverlapParams.new()
-		preciseParams.FilterType = Enum.RaycastFilterType.Whitelist
+		preciseParams.FilterType = Enum.RaycastFilterType.Include
 		preciseParams.MaxParts = totalRemainingBoundParts
 		preciseParams.FilterDescendantsInstances = boundPartsThatRequirePreciseChecks
 

--- a/src/Zone/init.lua
+++ b/src/Zone/init.lua
@@ -303,13 +303,13 @@ function Zone:_update()
 	self.allZonePartsAreBlocks = allZonePartsAreBlocksNew
 	
 	local zonePartsWhitelist = OverlapParams.new()
-	zonePartsWhitelist.FilterType = Enum.RaycastFilterType.Whitelist
+	zonePartsWhitelist.FilterType = Enum.RaycastFilterType.Include
 	zonePartsWhitelist.MaxParts = #zoneParts
 	zonePartsWhitelist.FilterDescendantsInstances = zoneParts
 	self.overlapParams.zonePartsWhitelist = zonePartsWhitelist
 
 	local zonePartsIgnorelist = OverlapParams.new()
-	zonePartsIgnorelist.FilterType = Enum.RaycastFilterType.Blacklist
+	zonePartsIgnorelist.FilterType = Enum.RaycastFilterType.Exclude
 	zonePartsIgnorelist.FilterDescendantsInstances = zoneParts
 	self.overlapParams.zonePartsIgnorelist = zonePartsIgnorelist
 	

--- a/src/Zone/init.lua
+++ b/src/Zone/init.lua
@@ -21,6 +21,50 @@ if referencePresent then
 	return require(referenceObject.Value)
 end
 
+export type Zone = {
+	-- Constructors
+	new: (container: Instance | BasePart | {BasePart}) -> Zone,
+	fromRegion: (cframe: CFrame, size: Vector3) -> Zone,
+	-- Methods
+	findLocalPlayer: (self: Zone) -> boolean,
+	findPlayer: (self: Zone, player: Player) -> boolean,
+	findPart: (self: Zone, basePart: BasePart) -> boolean,
+	findItem: (self: Zone, basePartOrCharacter: BasePart | Model) -> boolean,
+	findPoint: (self: Zone, position: Vector3) -> boolean,
+	getPlayers: (self: Zone) -> {Player},
+	getParts: (self: Zone) -> {BasePart},
+	getItems: (self: Zone) -> {BasePart | Model},
+	getRandomPoint: (self: Zone) -> (Vector3, {BasePart}),
+	trackItem: (self: Zone, characterOrBasePart: Model | BasePart) -> (),
+	untrackItem: (self: Zone, characterOrBasePart: Model | BasePart) -> (),
+	bindToGroup: (self: Zone, settingsGroupName: {onlyEnterOnceExitedAll: boolean}) -> (),
+	unbindFromGroup: (self: Zone) -> (),
+	setDetection: (self: Zone, enumIdOrName: "WholeBody" | "Centre") -> {BasePart},
+	relocate: (self: Zone) -> (),
+	onItemEnter: (self: Zone, characterOrBasePart: Model | BasePart, callbackFunction: (...any) -> ()) -> (),
+	onItemExit: (self: Zone, characterOrBasePart: Model | BasePart, callbackFunction: (...any) -> ()) -> (),
+	destroy: (self: Zone) -> (),
+	-- Events
+	localPlayerEntered: Signal.Signal,
+	localPlayerExited: Signal.Signal,
+	playerEntered: Signal.Signal,
+	playerExited: Signal.Signal,
+	partEntered: Signal.Signal,
+	partExited: Signal.Signal,
+	itemEntered: Signal.Signal,
+	itemExited: Signal.Signal,
+	-- Properties
+	accuracy: "Low" | "Medium" | "High" | "Precise",
+	enterDetection: "WholeBody" | "Centre",
+	exitDetection: "WholeBody" | "Centre",
+	autoUpdate: boolean,
+	respectUpdateQueue: boolean,
+	zoneParts: {BasePart},
+	region: Region3,
+	volume: number,
+	worldModel: Instance
+}
+
 local Zone = {}
 Zone.__index = Zone
 if not referencePresent then
@@ -31,7 +75,7 @@ Zone.enum = enum
 
 
 -- CONSTRUCTORS
-function Zone.new(container)
+function Zone.new(container): Zone
 	local self = {}
 	setmetatable(self, Zone)
 	
@@ -141,10 +185,10 @@ function Zone.new(container)
 		ZoneController._deregisterZone(self)
 	end, true)
 	
-	return self
+	return self :: Zone
 end
 
-function Zone.fromRegion(cframe, size)
+function Zone.fromRegion(cframe, size): Zone
 	local MAX_PART_SIZE = 2024
 	local container = Instance.new("Model")
 	local function createCube(cubeCFrame, cubeSize)


### PR DESCRIPTION
This PR aims to add full types for Zone and Signal for easier auto completion. They are manually typed and compatible with Rojo. It also fixes the library using deprecated parameters for **RaycastFilterType**.

![image](https://github.com/1ForeverHD/ZonePlus/assets/36084202/7afbd7fe-745f-4bea-a1fc-dadd631cc25b)
