### PR TITLE
Bug/fixed old signal issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
+# README
+
+This is the Devhouse fork of 1ForeverHD's ZonePlus
+
+if adding as a submodule, add from the `release-package` branch, not `main`, for a smoother setup within a Devhouse project
+
+# Original Documentation/Readme:
 https://1foreverhd.github.io/ZonePlus/

--- a/default.project.json
+++ b/default.project.json
@@ -1,14 +1,6 @@
 {
   "name": "ZonePlus",
   "tree": {
-    "$className": "DataModel",
-
-    "ReplicatedStorage": {
-      "$className": "ReplicatedStorage",
-
-      "Zone": {
-        "$path": "src/Zone"
-      }
-    }
+    "$path": "src/Zone"
   }
 }

--- a/src/Zone/Signal.lua
+++ b/src/Zone/Signal.lua
@@ -92,7 +92,8 @@ end
 -- Make Connection strict
 setmetatable(Connection, {
 	__index = function(tb, key)
-		error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
+		--that's stupid. don't do that.
+		-- error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
 	end,
 	__newindex = function(tb, key, value)
 		error(("Attempt to set Connection::%s (not a valid member)"):format(tostring(key)), 2)


### PR DESCRIPTION
Made it allow querying indexes not found in it instead of throwing an immediate error so that Trove can test for the presence of particular functions