### PR TITLE
fix invalid tarmac tool version and rojo project.json config

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,14 +1,6 @@
 {
   "name": "ZonePlus",
   "tree": {
-    "$className": "DataModel",
-
-    "ReplicatedStorage": {
-      "$className": "ReplicatedStorage",
-
-      "Zone": {
-        "$path": "src/Zone"
-      }
-    }
+    "$path": "src"
   }
 }

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,4 +1,4 @@
 [tools]
 rojo = { source = "rojo-rbx/rojo", version = "6.0.2" }
-tarmac = { source = "rojo-rbx/tarmac", version = "0.4.0" }
+tarmac = { source = "rojo-rbx/tarmac", version = "0.7.5" }
 wally = { source = "UpliftGames/Wally", version = "0.3.2" }


### PR DESCRIPTION
Fixes a failing step on the `PublishAssets.yml` GitHub action by updating `tarmac` to its latest version.