### PR TITLE
Fix self table reference

### DIFF
--- a/src/Zone/init.lua
+++ b/src/Zone/init.lua
@@ -635,7 +635,7 @@ end
 function Zone:_getAll(trackerName)
 	ZoneController.updateDetection(self)
 	local itemsArray = {}
-	local zonesAndOccupants = ZoneController._getZonesAndItems(trackerName, {self = true}, self.volume, false, self._currentEnterDetection)
+	local zonesAndOccupants = ZoneController._getZonesAndItems(trackerName, {[self] = true}, self.volume, false, self._currentEnterDetection)
 	local occupantsDict = zonesAndOccupants[self]
 	if occupantsDict then
 		for item, _ in pairs(occupantsDict) do


### PR DESCRIPTION
Referencing "self" without brackets makes it a string reference, resulting an an error when calling :getItems() on a Zone with a volume smaller than the volume of players in the game.

![image](https://github.com/1ForeverHD/ZonePlus/assets/29686338/6af91170-e8f8-40f4-8cfb-568fc501a331)
