### PR TITLE
Update Tracker.lua | Replace deprecated RaycastFilterType properties

### DIFF
--- a/src/Zone/ZoneController/Tracker.lua
+++ b/src/Zone/ZoneController/Tracker.lua
@@ -230,7 +230,7 @@ function Tracker:update()
 	
 	-- This creates the whitelist so that
 	self.whitelistParams = OverlapParams.new()
-	self.whitelistParams.FilterType = Enum.RaycastFilterType.Whitelist
+	self.whitelistParams.FilterType = Enum.RaycastFilterType.Include
 	self.whitelistParams.MaxParts = #self.parts
 	self.whitelistParams.FilterDescendantsInstances = self.parts
 end

--- a/src/Zone/ZoneController/init.lua
+++ b/src/Zone/ZoneController/init.lua
@@ -413,7 +413,7 @@ function ZoneController.getTouchingZones(item, onlyActiveZones, recommendedDetec
 	local partToZoneDict = (onlyActiveZones and activePartToZone) or allPartToZone
 
 	local boundParams = OverlapParams.new()
-	boundParams.FilterType = Enum.RaycastFilterType.Whitelist
+	boundParams.FilterType = Enum.RaycastFilterType.Include
 	boundParams.MaxParts = #partsTable
 	boundParams.FilterDescendantsInstances = partsTable
 
@@ -442,7 +442,7 @@ function ZoneController.getTouchingZones(item, onlyActiveZones, recommendedDetec
 	if totalRemainingBoundParts > 0 then
 		
 		local preciseParams = OverlapParams.new()
-		preciseParams.FilterType = Enum.RaycastFilterType.Whitelist
+		preciseParams.FilterType = Enum.RaycastFilterType.Include
 		preciseParams.MaxParts = totalRemainingBoundParts
 		preciseParams.FilterDescendantsInstances = boundPartsThatRequirePreciseChecks
 


### PR DESCRIPTION
Replaced
Enum.RaycastFilterType.Whitelist
To
Enum.RaycastFilterType.Include

To prevent deprecation warning